### PR TITLE
PHP 7.1 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ php:
     - 7.4
     - 7.3
     - 7.2
+    - 7.1
 
 before_script:
     - echo "memory_limit=4096M" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,5 +37,5 @@ All notable changes to `currency` will be documented in this file
 - cut sfneal/actions from composer requirements
  
  
-## 2.0.0 - 2021-08-31
+## 2.0.1 - 2021-08-31
 - add support for php7.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,3 +39,4 @@ All notable changes to `currency` will be documented in this file
  
 ## 2.0.1 - 2021-08-31
 - add support for php7.1
+- fix min phpunit/phpunit version to support php7.1 & use of `assertIsString()` method

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,3 +35,7 @@ All notable changes to `currency` will be documented in this file
 - make `Currency` class with static `format()` method to improve syntax
 - cut `FormatDollars` actions class
 - cut sfneal/actions from composer requirements
+ 
+ 
+## 2.0.0 - 2021-08-31
+- add support for php7.1

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "php": ">=7.1"
     },
     "require-dev": {
-        "phpunit/phpunit": ">=8.0.0",
+        "phpunit/phpunit": ">=6.5.14",
         "scrutinizer/ocular": "^1.8"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": ">=7.2"
+        "php": ">=7.1"
     },
     "require-dev": {
         "phpunit/phpunit": ">=8.0.0",

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "php": ">=7.1"
     },
     "require-dev": {
-        "phpunit/phpunit": ">=6.5.14",
+        "phpunit/phpunit": ">=7.5",
         "scrutinizer/ocular": "^1.8"
     },
     "autoload": {


### PR DESCRIPTION
- add support for php7.1
- fix min phpunit/phpunit version to support php7.1 & use of `assertIsString()` method